### PR TITLE
Use '-' instead of '_' as an organization name in mix.exs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Example sequence up to compilation:
 ```sh
 $ git clone https://github.com/access-company/testgear.git
 $ cd testgear
-$ ANTIKYTHERA_INSTANCE_DEP='{:instance_name, [git: "git@github.com:your_organization/instance_name.git"]}'
+$ ANTIKYTHERA_INSTANCE_DEP='{:instance_name, [git: "git@github.com:your-organization/instance_name.git"]}'
 $ export ANTIKYTHERA_INSTANCE_DEP
 $ mix deps.get
-* Getting instance_name (git@github.com:your_organization/instance_name.git)
+* Getting instance_name (git@github.com:your-organization/instance_name.git)
 ... (snip)
 
 $ mix deps.get # Fetch dev/test-only dependencies declared in instance_name

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ dep_env_var = "ANTIKYTHERA_INSTANCE_DEP"
 help_message = """
 #{dep_env_var} must be a proper mix dependency tuple! Example:
 
-{:instance_name, [git: "git@github.com:your_organization/antikythera_instance_name.git"]}
+{:instance_name, [git: "git@github.com:your-organization/antikythera_instance_name.git"]}
 
 """
 


### PR DESCRIPTION
As mentioned in https://github.com/access-company/antikythera_console/pull/7#pullrequestreview-170541999, we cannot use '_' as an organization name of GitHub, so I fixed it.