### PR TITLE
[185700] Get elixir version from antikythera repository in CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             echo 'source /usr/local/asdf/asdf.sh' >> $BASH_ENV
             source $BASH_ENV
             asdf plugin-add elixir || asdf plugin-update elixir
-            elixir_version="$(curl https://raw.githubusercontent.com/access-company/antikythera_instance_example/master/.tool-versions | grep elixir)"
+            elixir_version="$(curl https://raw.githubusercontent.com/access-company/antikythera/master/.tool-versions | grep elixir)"
             asdf install ${elixir_version}
             asdf global ${elixir_version}
             mix local.hex --force

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,9 @@ jobs:
             echo 'source /usr/local/asdf/asdf.sh' >> $BASH_ENV
             source $BASH_ENV
             asdf plugin-add elixir || asdf plugin-update elixir
-            asdf install elixir 1.7.4
-            asdf global elixir 1.7.4
+            elixir_version="$(curl https://raw.githubusercontent.com/access-company/antikythera_instance_example/master/.tool-versions | grep elixir)"
+            asdf install ${elixir_version}
+            asdf global ${elixir_version}
             mix local.hex --force
             mix local.rebar --force
       - save_cache:


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/185700

Get elixir version from [this file](https://github.com/access-company/antikythera_instance_example/blob/master/.tool-versions) rather than update manually.