### PR TITLE
[185700] change deprecated time unit `:milliseconds` to `:millisecond`

### DIFF
--- a/test/async_job_test.exs
+++ b/test/async_job_test.exs
@@ -236,7 +236,7 @@ defmodule Testgear.AsyncJobTest do
   test "recurring job should be requeued on completion" do
     job_starter_pid = timed_job_starter_pid()
     job_id = "foobar"
-    now_millis = System.system_time(:milliseconds)
+    now_millis = System.system_time(:millisecond)
 
     # tweak first execution time on job registration
     {Time, _ymd, {_h, m1, _s}, _} = Time.now()


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/185700

Time unit `:milliseconds` is deprecated from Elixir 1.8.
https://github.com/elixir-lang/elixir/blob/v1.8/CHANGELOG.md#elixir-4