### PR TITLE
[206806] Access Antikythera API via 127.0.0.1

### DIFF
--- a/test/system_info_exporter_test.exs
+++ b/test/system_info_exporter_test.exs
@@ -7,7 +7,7 @@ defmodule Testgear.SystemInfoExporterTest do
   alias AntikytheraCore.Handler.SystemInfoExporter.AccessToken
   require AntikytheraCore.Logger, as: L
 
-  @base_url "http://localhost:#{Antikythera.Env.port_to_listen()}"
+  @base_url "http://127.0.0.1:#{Antikythera.Env.port_to_listen()}"
 
   setup do
     :meck.new(Time, [:passthrough])

--- a/test/system_info_exporter_test.exs
+++ b/test/system_info_exporter_test.exs
@@ -59,6 +59,7 @@ defmodule Testgear.SystemInfoExporterTest do
     Map.values(m) |> Enum.sum()
   end
 
+  @tag capture_log: true
   test "/error_count/:otp_app_name and /error_count/_total" do
     # flush existing error counts
     t1 = Time.now() |> Time.truncate_to_minute() |> Time.shift_minutes(1)


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/206806

After merging https://github.com/access-company/antikythera/pull/133, We can no longer access the antikythera API via localhost (local environment only).