### PR TITLE
[309541] Fix a test error on OTP 25

### DIFF
--- a/test/system_info_exporter_test.exs
+++ b/test/system_info_exporter_test.exs
@@ -52,7 +52,7 @@ defmodule Testgear.SystemInfoExporterTest do
   end
 
   test "/error_count/:otp_app_name should reject request for nonexisting OTP application" do
-    res = get_with_token("/error_count/nonexisting")
+    res = get_with_token("/error_count/abcnonexistingxyz")
     assert res.status == 404
     assert res.body   == ""
   end


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/309541

It looks like OTP 25 adds `:nonexisting`. Let's change the non existing atom more unrealistic one.