### PR TITLE
[310966] Add a basic auth test via Hackney `:basic_auth` option

### DIFF
--- a/test/basic_authentication_test.exs
+++ b/test/basic_authentication_test.exs
@@ -6,10 +6,17 @@ defmodule Testgear.BasicAuthenticationTest do
 
   @path_list ["/basic_authentication_with_config", "/basic_authentication_with_fun"]
 
-  test "should pass basic authentication" do
+  test "should pass basic authentication via authorization header" do
     credential = "Basic " <> Base.encode64("admin:password")
     Enum.each(@path_list, fn path ->
       res = Req.get(path, %{"authorization" => credential})
+      assert res.status == 200
+    end)
+  end
+
+  test "should pass basic authentication via basic_auth option" do
+    Enum.each(@path_list, fn path ->
+      res = Req.get(path, %{}, basic_auth: {"admin", "password"})
       assert res.status == 200
     end)
   end


### PR DESCRIPTION
https://acsmine.tok.access-company.com/redmine/issues/310966

Added a test for detecting the issue with the `insecure_basic_auth` option since Hackney 1.24.0.
`Antikythera.Test.HttpClient` uses an insecure HTTP connection for local testing, which leads to an error during testing when the `insecure_basic_auth` option is set to `false`.